### PR TITLE
Solving startup problem ( ClassNotFoundException ) 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
               <addClasspath>true</addClasspath>
               <classpathPrefix>lib/</classpathPrefix>
               <mainClass>org.jboss.aesh.cloverxell.AppMain</mainClass>
+              <overWriteIfNewer>true</overWriteIfNewer>
               <useUniqueVersions>false</useUniqueVersions>
             </manifest>
             <manifestEntries>


### PR DESCRIPTION
Solving startup problem, when the maven was building the executable jar was creating a wrong manifest entry to cloverx library into MANIFEST.MF file
