### PR TITLE
#123 Add simple log apis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ nanook.iml
 *~
 .*
 !/.gitignore
-
+*.log

--- a/src/main/java/org/jboss/aesh/nanook/Log.java
+++ b/src/main/java/org/jboss/aesh/nanook/Log.java
@@ -1,0 +1,32 @@
+package org.jboss.aesh.nanook;
+
+import java.time.LocalDateTime;
+
+/**
+ * @author Yoshimasa Tanabe
+ */
+public class Log {
+
+    private LocalDateTime time;
+    private String level;
+    private String message;
+
+    public Log(LocalDateTime time, String level, String message) {
+        this.time = time;
+        this.level = level;
+        this.message = message;
+    }
+
+    public LocalDateTime getTime() {
+        return time;
+    }
+
+    public String getLevel() {
+        return level;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/src/main/java/org/jboss/aesh/nanook/Main.java
+++ b/src/main/java/org/jboss/aesh/nanook/Main.java
@@ -13,14 +13,16 @@
 package org.jboss.aesh.nanook;
 
 import org.wildfly.swarm.container.Container;
-import org.wildfly.swarm.undertow.WarDeployment;
 import org.wildfly.swarm.jaxrs.JAXRSDeployment;
 import org.wildfly.swarm.logging.LoggingFraction;
+import org.wildfly.swarm.undertow.WarDeployment;
 
 /**
  * @author <a href='mailto:00hf11@gmail.com'>Helio Frota</a>
  */
 public class Main {
+
+    private static final String LOG_LEVEL = System.getProperty("nanook.log.level", "DEBUG");
 
     public static void main(String... args) throws Exception {
 
@@ -28,8 +30,13 @@ public class Main {
         Container container = new Container();
         
         // logging config.
-        container.subsystem(LoggingFraction.createDebugLoggingFraction());
-        
+        container.subsystem(new LoggingFraction()
+                .defaultColorFormatter()
+                .formatter("TSV", "%d{yyyy-MM-dd HH:mm:ss,SSS}\t%-5p\t[%c] (%t) %s%e%n")
+                .consoleHandler(LOG_LEVEL, "COLOR_PATTERN")
+                .fileHandler("FILE", "nanook.log", LOG_LEVEL, "TSV")
+                .rootLogger(LOG_LEVEL, "CONSOLE", "FILE"));
+
         // war configuration.
         WarDeployment war = new JAXRSDeployment(container);
         war.staticContent("/");


### PR DESCRIPTION
I added simple two log APIs(text and json response).

## Usage

### text

[logAsText](https://github.com/aeshell/nanook/compare/master...emag:expose-wildfly-swarm-logs-with-rest?expand=1#diff-651c14a48916bf765af92a6058b41478R54) just returns content of the log file(nanook.log) like history api.

``` sh
$ curl localhost:8080/log   
2015-06-25 00:48:50,766	INFO 	[org.wildfly.extension.io] (ServerService Thread Pool -- 8) WFLYIO001: Worker 'default' has auto-configured to 16 core threads with 128 task threads based on your 8 available processors
2015-06-25 00:48:50,767	INFO 	[org.jboss.as.naming] (ServerService Thread Pool -- 12) WFLYNAM0001: Activating Naming Subsystem
2015-06-25 00:48:50,780	INFO 	[org.jboss.as.naming] (MSC service thread 1-4) WFLYNAM0003: Starting Naming Service
2015-06-25 00:48:50,782	DEBUG	[org.jboss.as.ee] (ServerService Thread Pool -- 11) Activating EE subsystem
...
```

### json

[logAsJson](https://github.com/aeshell/nanook/compare/master...emag:expose-wildfly-swarm-logs-with-rest?expand=1#diff-651c14a48916bf765af92a6058b41478R68) returns the log formatted JSON. The attributes are time, level, message.

And now the api collects only lines start with time because I don't think of a good way to parse error message(mainly stack trace lines).

Though the format of time is JavaScript friendly, it's a little verbose...

``` sh
$ curl -H "Accept: application/json" localhost:8080/log | jq . 
...
[
  {
    "message": "[org.wildfly.extension.io] (ServerService Thread Pool -- 8) WFLYIO001: Worker 'default' has auto-configured to 16 core threads with 128 task threads based on your 8 available processors",
    "level": "INFO",
    "time": {
      "chronology": {
        "id": "ISO",
        "calendarType": "iso8601"
      },
      "monthValue": 6,
      "dayOfYear": 176,
      "nano": 7.66e+08,
      "second": 50,
      "hour": 0,
      "minute": 48,
      "month": "JUNE",
      "year": 2015,
      "dayOfMonth": 25,
      "dayOfWeek": "THURSDAY"
    }
  },
  ...
]
```